### PR TITLE
Add Thundercloud and Firestarter procs to the Statuseffect tab for BLM

### DIFF
--- a/Config/Tabs/StatusEffectsTab.cs
+++ b/Config/Tabs/StatusEffectsTab.cs
@@ -69,6 +69,8 @@ namespace RemindMe {
                         StatusMonitorConfigDisplay(162, 24); // Thunder II
                         StatusMonitorConfigDisplay(163, 24); // Thunder III
                         StatusMonitorConfigDisplay(1210, 18); // Thunder IV
+                        StatusMonitorConfigDisplay(164, 18, selfOnly: true); // Thundercloud procs on player
+                        StatusMonitorConfigDisplay(165, 18, selfOnly: true); // Firestarter procs on player
                         break;
                     }
                 case 26:


### PR DESCRIPTION
Title basically. It is very good to be able to keep track how long your procs last on BLM since you want to use especially thundercloud procs as late as possible without them dropping though