### PR TITLE
add numerous status effects

### DIFF
--- a/Config/Tabs/StatusEffectsTab.cs
+++ b/Config/Tabs/StatusEffectsTab.cs
@@ -29,7 +29,19 @@ namespace RemindMe {
             switch (pluginInterface.ClientState.LocalPlayer.ClassJob.Id) {
                 case 19: {
                         // PLD
+                        StatusMonitorConfigDisplay(76, 25); // Fight or Flight
+                        StatusMonitorConfigDisplay(1368, 12); // Requiescat
                         StatusMonitorConfigDisplay(725, 21); // Goring Blade
+                        StatusMonitorConfigDisplay(248, 15); // Circle of Scorn
+                        StatusMonitorConfigDisplay(74, 15); // Sentinel
+                        StatusMonitorConfigDisplay(82, 10); // Hallowed Ground
+                        StatusMonitorConfigDisplay(1175, 18); // Passage of Arms
+                        StatusMonitorConfigDisplay(726, 30); // Divine Veil
+                        StatusMonitorConfigDisplay(727, 30, note: "shield"); // Divine Veil Shield
+                        StatusMonitorConfigDisplay(1856, 5); // Shelltron
+                        StatusMonitorConfigDisplay(1174, 6); // Intervention
+                        StatusMonitorConfigDisplay(81, 12); // Cover
+                        tankRoleEffects();
                         break;
                 }
                 case 20: {
@@ -39,7 +51,20 @@ namespace RemindMe {
                     }
                 case 21: {
                         // WAR
+                        StatusMonitorConfigDisplay(86, 10); // Berserk
                         StatusMonitorConfigDisplay(90, 60, selfOnly: true); // Storm's Path
+                        StatusMonitorConfigDisplay(87, 10); // Thrill of Battle
+                        StatusMonitorConfigDisplay(89, 15); // Vengeance
+                        StatusMonitorConfigDisplay(409, 8); // Holmgang
+                        StatusMonitorConfigDisplay(735, 6); // Raw Intuition
+                        StatusMonitorConfigDisplay(1457, 15); // Shake it Off
+
+                        // TODO: Obtain Ability IDs (my WAR is too low level to use these)
+                        // StatusMonitorConfigDisplay(xxx, 10); // Inner Release (Possibly same buff as Berserk?)
+                        // StatusMonitorConfigDisplay(xxx, 6); // Nascent Flash
+
+
+                        tankRoleEffects();
                         break;
                     }
                 case 22: {
@@ -66,6 +91,11 @@ namespace RemindMe {
                         StatusMonitorConfigDisplay(1871, 30); // Dia
                         StatusMonitorConfigDisplay(158, 18); // Regen
                         StatusMonitorConfigDisplay(150, 15); // Medica II
+                        StatusMonitorConfigDisplay(157, 15); // Presence of Mind
+                        StatusMonitorConfigDisplay(1217, 12); // Thin Air
+                        StatusMonitorConfigDisplay(1218, 15); // Divine Benison
+                        StatusMonitorConfigDisplay(1219, 10); // Confession
+                        StatusMonitorConfigDisplay(1872, 20); // Temperance
 
                         break;
                     }
@@ -106,7 +136,29 @@ namespace RemindMe {
                 case 31: {
                         // MCH
                         // 1866
+                        StatusMonitorConfigDisplay(851, 5); // Reassembled
+                        StatusMonitorConfigDisplay(1951, 15); // Tactician
+                        StatusMonitorConfigDisplay(1205, 10); // Flamethrower
                         StatusMonitorConfigDisplay(1866, 15); // Bio Blaster
+                        break;
+                    }
+                case 32:
+                    {
+                        // DRK
+                        StatusMonitorConfigDisplay(742, 10); // Blood Weapon
+                        StatusMonitorConfigDisplay(747, 15); // Shadow Wall
+                        StatusMonitorConfigDisplay(746, 10); // Dark Mind
+                        StatusMonitorConfigDisplay(810, 10); // Living Dead
+                        StatusMonitorConfigDisplay(811, 10); // Walking Dead
+                        StatusMonitorConfigDisplay(749, 15); // Salted Earth
+                        StatusMonitorConfigDisplay(1972, 10); // Delirium
+                        StatusMonitorConfigDisplay(1178, 7); // Blackest Night
+
+                        // TODO: Obtain Ability IDs (my DRK is too low level to use these)
+                        // StatusMonitorConfigDisplay(xxx, 15); // Dark Missionary
+                        // StatusMonitorConfigDisplay(xxx, 24); // Living Shadow
+
+                        tankRoleEffects();
                         break;
                     }
                 case 33: {
@@ -123,6 +175,17 @@ namespace RemindMe {
                         StatusMonitorConfigDisplay(1228, 60); // Higanbana
                         break;
                     }
+                case 35:
+                    {
+                        // RDM
+                        StatusMonitorConfigDisplay(1234, 30); // Verfire Ready
+                        StatusMonitorConfigDisplay(1235, 30); // Verstone Ready
+                        StatusMonitorConfigDisplay(1238, 20); // Acceleration
+                        StatusMonitorConfigDisplay(1239, 20); // Embolden
+                        StatusMonitorConfigDisplay(1971, 10); // Manification
+                        StatusMonitorConfigDisplay(1249, 15); // Dualcast
+                        break;
+                    }
                 case 36: {
                         // BLU
                         StatusMonitorConfigDisplay(1714, 30, "Song of Torment"); // Song of Torment
@@ -133,7 +196,19 @@ namespace RemindMe {
                         break;
                     }
                 case 37: {
+                        // GNB
+                        StatusMonitorConfigDisplay(1831, 20); // No Mercy
                         StatusMonitorConfigDisplay(1837, 30); // Sonic Break
+                        StatusMonitorConfigDisplay(1838, 15); // Bow Shock
+                        StatusMonitorConfigDisplay(1835, 18); // Aurora
+                        StatusMonitorConfigDisplay(1839, 15); // Heart of Light
+                        StatusMonitorConfigDisplay(1840, 7); // Heart of Stone
+                        StatusMonitorConfigDisplay(1898, 30); // Brutal Shell
+                        StatusMonitorConfigDisplay(1832, 20); // Camouflage
+                        StatusMonitorConfigDisplay(1834, 15); // Nebula
+                        StatusMonitorConfigDisplay(1836, 8); // Superbolide
+                        tankRoleEffects();
+
                         break;
                     }
                 default: {
@@ -148,5 +223,15 @@ namespace RemindMe {
             ImGui.EndChild();
             
         }
+
+        private void tankRoleEffects()
+        {
+            StatusMonitorConfigDisplay(1209, 6); // Arm's Length
+            StatusMonitorConfigDisplay(9, 15, note: "from Arm's Length"); // Arm's Length Slow
+            StatusMonitorConfigDisplay(2, 5, note: "from Low Blow"); // Low Blow Stun
+            StatusMonitorConfigDisplay(1191, 20); // Rampart
+            StatusMonitorConfigDisplay(1193, 10); // Reprisal
+        }
     }
+
 }

--- a/Config/Tabs/StatusEffectsTab.cs
+++ b/Config/Tabs/StatusEffectsTab.cs
@@ -29,16 +29,16 @@ namespace RemindMe {
             switch (pluginInterface.ClientState.LocalPlayer.ClassJob.Id) {
                 case 19: {
                         // PLD
-                        StatusMonitorConfigDisplay(76, 25); // Fight or Flight
-                        StatusMonitorConfigDisplay(1368, 12); // Requiescat
+                        StatusMonitorConfigDisplay(76, 25, selfOnly: true); // Fight or Flight
+                        StatusMonitorConfigDisplay(1368, 12, selfOnly: true); // Requiescat
                         StatusMonitorConfigDisplay(725, 21); // Goring Blade
                         StatusMonitorConfigDisplay(248, 15); // Circle of Scorn
-                        StatusMonitorConfigDisplay(74, 15); // Sentinel
-                        StatusMonitorConfigDisplay(82, 10); // Hallowed Ground
+                        StatusMonitorConfigDisplay(74, 15, selfOnly: true); // Sentinel
+                        StatusMonitorConfigDisplay(82, 10, selfOnly: true); // Hallowed Ground
                         StatusMonitorConfigDisplay(1175, 18); // Passage of Arms
-                        StatusMonitorConfigDisplay(726, 30); // Divine Veil
+                        StatusMonitorConfigDisplay(726, 30, selfOnly: true); // Divine Veil
                         StatusMonitorConfigDisplay(727, 30, note: "shield"); // Divine Veil Shield
-                        StatusMonitorConfigDisplay(1856, 5); // Shelltron
+                        StatusMonitorConfigDisplay(1856, 5, selfOnly: true); // Shelltron
                         StatusMonitorConfigDisplay(1174, 6); // Intervention
                         StatusMonitorConfigDisplay(81, 12); // Cover
                         tankRoleEffects();
@@ -51,18 +51,17 @@ namespace RemindMe {
                     }
                 case 21: {
                         // WAR
-                        StatusMonitorConfigDisplay(86, 10); // Berserk
+                        StatusMonitorConfigDisplay(86, 10, selfOnly: true); // Berserk
                         StatusMonitorConfigDisplay(90, 60, selfOnly: true); // Storm's Path
-                        StatusMonitorConfigDisplay(87, 10); // Thrill of Battle
-                        StatusMonitorConfigDisplay(89, 15); // Vengeance
-                        StatusMonitorConfigDisplay(409, 8); // Holmgang
+                        StatusMonitorConfigDisplay(87, 10, selfOnly: true); // Thrill of Battle
+                        StatusMonitorConfigDisplay(89, 15, selfOnly: true); // Vengeance
+                        StatusMonitorConfigDisplay(409, 8, selfOnly: true); // Holmgang
                         StatusMonitorConfigDisplay(735, 6); // Raw Intuition
                         StatusMonitorConfigDisplay(1457, 15); // Shake it Off
 
                         // TODO: Obtain Ability IDs (my WAR is too low level to use these)
                         // StatusMonitorConfigDisplay(xxx, 10); // Inner Release (Possibly same buff as Berserk?)
                         // StatusMonitorConfigDisplay(xxx, 6); // Nascent Flash
-
 
                         tankRoleEffects();
                         break;
@@ -91,11 +90,11 @@ namespace RemindMe {
                         StatusMonitorConfigDisplay(1871, 30); // Dia
                         StatusMonitorConfigDisplay(158, 18); // Regen
                         StatusMonitorConfigDisplay(150, 15); // Medica II
-                        StatusMonitorConfigDisplay(157, 15); // Presence of Mind
-                        StatusMonitorConfigDisplay(1217, 12); // Thin Air
+                        StatusMonitorConfigDisplay(157, 15, selfOnly: true); // Presence of Mind
+                        StatusMonitorConfigDisplay(1217, 12, selfOnly: true); // Thin Air
                         StatusMonitorConfigDisplay(1218, 15); // Divine Benison
                         StatusMonitorConfigDisplay(1219, 10); // Confession
-                        StatusMonitorConfigDisplay(1872, 20); // Temperance
+                        StatusMonitorConfigDisplay(1872, 20, selfOnly: true); // Temperance
 
                         break;
                     }
@@ -136,22 +135,22 @@ namespace RemindMe {
                 case 31: {
                         // MCH
                         // 1866
-                        StatusMonitorConfigDisplay(851, 5); // Reassembled
+                        StatusMonitorConfigDisplay(851, 5, selfOnly: true); // Reassembled
                         StatusMonitorConfigDisplay(1951, 15); // Tactician
-                        StatusMonitorConfigDisplay(1205, 10); // Flamethrower
+                        StatusMonitorConfigDisplay(1205, 10, selfOnly: true); // Flamethrower
                         StatusMonitorConfigDisplay(1866, 15); // Bio Blaster
                         break;
                     }
                 case 32:
                     {
                         // DRK
-                        StatusMonitorConfigDisplay(742, 10); // Blood Weapon
-                        StatusMonitorConfigDisplay(747, 15); // Shadow Wall
-                        StatusMonitorConfigDisplay(746, 10); // Dark Mind
-                        StatusMonitorConfigDisplay(810, 10); // Living Dead
-                        StatusMonitorConfigDisplay(811, 10); // Walking Dead
-                        StatusMonitorConfigDisplay(749, 15); // Salted Earth
-                        StatusMonitorConfigDisplay(1972, 10); // Delirium
+                        StatusMonitorConfigDisplay(742, 10, selfOnly: true); // Blood Weapon
+                        StatusMonitorConfigDisplay(747, 15, selfOnly: true); // Shadow Wall
+                        StatusMonitorConfigDisplay(746, 10, selfOnly: true); // Dark Mind
+                        StatusMonitorConfigDisplay(810, 10, selfOnly: true); // Living Dead
+                        StatusMonitorConfigDisplay(811, 10, selfOnly: true); // Walking Dead
+                        StatusMonitorConfigDisplay(749, 15, selfOnly: true); // Salted Earth
+                        StatusMonitorConfigDisplay(1972, 10, selfOnly: true); // Delirium
                         StatusMonitorConfigDisplay(1178, 7); // Blackest Night
 
                         // TODO: Obtain Ability IDs (my DRK is too low level to use these)
@@ -178,12 +177,12 @@ namespace RemindMe {
                 case 35:
                     {
                         // RDM
-                        StatusMonitorConfigDisplay(1234, 30); // Verfire Ready
-                        StatusMonitorConfigDisplay(1235, 30); // Verstone Ready
-                        StatusMonitorConfigDisplay(1238, 20); // Acceleration
+                        StatusMonitorConfigDisplay(1234, 30, selfOnly: true); // Verfire Ready
+                        StatusMonitorConfigDisplay(1235, 30, selfOnly: true); // Verstone Ready
+                        StatusMonitorConfigDisplay(1238, 20, selfOnly: true); // Acceleration
                         StatusMonitorConfigDisplay(1239, 20); // Embolden
-                        StatusMonitorConfigDisplay(1971, 10); // Manification
-                        StatusMonitorConfigDisplay(1249, 15); // Dualcast
+                        StatusMonitorConfigDisplay(1971, 10, selfOnly: true); // Manification
+                        StatusMonitorConfigDisplay(1249, 15, selfOnly: true); // Dualcast
                         break;
                     }
                 case 36: {
@@ -197,16 +196,16 @@ namespace RemindMe {
                     }
                 case 37: {
                         // GNB
-                        StatusMonitorConfigDisplay(1831, 20); // No Mercy
+                        StatusMonitorConfigDisplay(1831, 20, selfOnly: true); // No Mercy
                         StatusMonitorConfigDisplay(1837, 30); // Sonic Break
                         StatusMonitorConfigDisplay(1838, 15); // Bow Shock
                         StatusMonitorConfigDisplay(1835, 18); // Aurora
                         StatusMonitorConfigDisplay(1839, 15); // Heart of Light
                         StatusMonitorConfigDisplay(1840, 7); // Heart of Stone
-                        StatusMonitorConfigDisplay(1898, 30); // Brutal Shell
-                        StatusMonitorConfigDisplay(1832, 20); // Camouflage
-                        StatusMonitorConfigDisplay(1834, 15); // Nebula
-                        StatusMonitorConfigDisplay(1836, 8); // Superbolide
+                        StatusMonitorConfigDisplay(1898, 30, selfOnly: true); // Brutal Shell
+                        StatusMonitorConfigDisplay(1832, 20, selfOnly: true); // Camouflage
+                        StatusMonitorConfigDisplay(1834, 15, selfOnly: true); // Nebula
+                        StatusMonitorConfigDisplay(1836, 8, selfOnly: true); // Superbolide
                         tankRoleEffects();
 
                         break;
@@ -226,10 +225,10 @@ namespace RemindMe {
 
         private void tankRoleEffects()
         {
-            StatusMonitorConfigDisplay(1209, 6); // Arm's Length
+            StatusMonitorConfigDisplay(1209, 6, selfOnly: true); // Arm's Length
             StatusMonitorConfigDisplay(9, 15, note: "from Arm's Length"); // Arm's Length Slow
             StatusMonitorConfigDisplay(2, 5, note: "from Low Blow"); // Low Blow Stun
-            StatusMonitorConfigDisplay(1191, 20); // Rampart
+            StatusMonitorConfigDisplay(1191, 20, selfOnly: true); // Rampart
             StatusMonitorConfigDisplay(1193, 10); // Reprisal
         }
     }


### PR DESCRIPTION
Per issue #9 I went ahead and added status effects for the various tank cooldowns. Also added a few other status effects for some other jobs I play since I was in there. I generally erred on the side of better to give users the a checkbox they may not check than not giving them the option at all.

Also I have a couple TODOs for effects for warrior and dark knight that I wasn't able to get ability ids for because I don't have those leveled to 80 so if you do and are feeling ambitious feel free to add those ids :D 

Love the plugin, thanks again!